### PR TITLE
Handled attribute associated error.

### DIFF
--- a/.idea/CodingWithMitchBlog-REST-API.iml
+++ b/.idea/CodingWithMitchBlog-REST-API.iml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="R User Library" level="project" />
+    <orderEntry type="library" name="R Skeletons" level="application" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/src/blog/templates" />
+      </list>
+    </option>
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="Unittests" />
+  </component>
+</module>

--- a/.idea/libraries/R_User_Library.xml
+++ b/.idea/libraries/R_User_Library.xml
@@ -1,0 +1,6 @@
+<component name="libraryTable">
+  <library name="R User Library">
+    <CLASSES />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.6" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/CodingWithMitchBlog-REST-API.iml" filepath="$PROJECT_DIR$/.idea/CodingWithMitchBlog-REST-API.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/blog/api/serializers.py
+++ b/src/blog/api/serializers.py
@@ -29,10 +29,14 @@ class BlogPostSerializer(serializers.ModelSerializer):
 
 	def validate_image_url(self, blog_post):
 		image = blog_post.image
-		new_url = image.url
-		if "?" in new_url:
-			new_url = image.url[:image.url.rfind("?")]
-		return new_url
+		if image:
+			new_url = image.url
+			if "?" in new_url:
+				new_url = image.url[:image.url.rfind("?")]
+			return new_url
+		else:
+			image = None
+			return image
 
 
 


### PR DESCRIPTION
BlogPostSerializer was returning "no attribute associated" error page when image path was set to null. 
Now after this patch it will return JSON with null value if the path is null.